### PR TITLE
Update bootstrap-slider version in bower.js to match blueprint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.20.0",
-    "seiyria-bootstrap-slider": "~5.2.6",
+    "seiyria-bootstrap-slider": "~6.0.6",
     "animate.css": "~3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The path to bootstrap-slider.js is wrong in index.js.  It looks like this is due to the wrong version in bower.json (doesn't match version in the blueprint)