### PR TITLE
#16 Initial state of disabled is ignored

### DIFF
--- a/addon/components/ui-slider.js
+++ b/addon/components/ui-slider.js
@@ -47,7 +47,14 @@ export default Ember.Component.extend({
   tooltipSplit: false, // if false only one tooltip for ranges, if true then tooltips for both
   handle: 'round', // values are round, square, triangle, or custom
   reversed: false,
-  enabled: true,
+  enabled: Ember.computed("disabled", {
+    get() {
+      return !this.get("disabled");
+    },
+    set(key, value) {
+      return value;
+    }
+  }),
   naturalArrowKeys: false,
   scale: 'linear',
   focus: false,


### PR DESCRIPTION
Hi Ken, i did a small fix to the issue #16 disabled initial state not working, the other alternative is to use enabled=true but the documentation mention that we can also use disabled, with this fix, enabled will always work but disabled as well, if both are present it's enabled that will be taken under consideration.