### PR TITLE
Fix contains deprecation

### DIFF
--- a/addon/components/ui-slider.js
+++ b/addon/components/ui-slider.js
@@ -94,7 +94,7 @@ export default Ember.Component.extend({
   }),
   sectionCalculator() {
     let {sections,min,max,value} = this.getProperties('sections','min','max','value');
-    if(!sections || new A(['null','undefined']).contains(value)) {
+    if(!sections || new A(['null','undefined']).includes(value)) {
       return null;
     }
     let section = 1;
@@ -293,7 +293,7 @@ export default Ember.Component.extend({
   },
   setDefaultValue() {
     let {defaultValue,value} = this.getProperties('defaultValue', 'value');
-    if(new A(['null','undefined']).contains(typeOf(value))) {
+    if(new A(['null','undefined']).includes(typeOf(value))) {
       defaultValue = typeOf(defaultValue) === 'string' && defaultValue.split(',').length > 1 ? defaultValue.split(',') : defaultValue;
       this.set('value', defaultValue);
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1"
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
In Ember 2.8, Array.contains() is deprecated in favor of Array.includes(), so update the two instances of .contains() and add the polyfill to make the code backwards compatible.