### PR TITLE
Add options to disable importing CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,28 @@
 /* jshint node: true */
 'use strict';
 
+var util = require('util');
+var extend = util._extend;
+
+var defaultOptions = {
+  importBootstrapSliderCSS: true,
+  importAddonCss: true
+};
+
 module.exports = {
   name: 'ui-slider',
   description: 'A flexible UI slider for ambitious Ember apps',
   included: function(app) {
-    let parentApp = (typeof app.import !== 'function' && app.app) ? app.app : app;
+    var parentApp = (typeof app.import !== 'function' && app.app) ? app.app : app;
+    var options = extend(defaultOptions, app.options['ui-slider']);
 
     parentApp.import('bower_components/seiyria-bootstrap-slider/dist/bootstrap-slider.js');
-    parentApp.import('bower_components/seiyria-bootstrap-slider/dist/css/bootstrap-slider.css');
-    parentApp.import('vendor/ui-slider/ui-slider.css');
+
+    if (options.importBootstrapSliderCSS) {
+      parentApp.import('bower_components/seiyria-bootstrap-slider/dist/css/bootstrap-slider.css');
+    }
+    if (options.importAddonCss) {
+      parentApp.import('vendor/ui-slider/ui-slider.css');
+    }
   }
 };


### PR DESCRIPTION
In case you want to write some custom CSS it makes more sense to not import the default one, instead of having to override everything. This adds some options (for the app's `ember-cli-build.js`) to opt out of importing the default CSS.

BTW, removed the use of `let` in `index.js`, because that is only available with node 4+.