### PR TITLE
Add support for ticks_tooltip option

### DIFF
--- a/addon/components/ui-slider.js
+++ b/addon/components/ui-slider.js
@@ -6,7 +6,7 @@ const snake = thingy => {
 };
 import layout from '../templates/components/ui-slider';
 const numericApiSurface = ['min','max','step','precision','ticksSnapBounds'];
-const booleanApiSurface = ['range','tooltipSplit','reversed','enabled','naturalArrowKeys','focus'];
+const booleanApiSurface = ['range','tooltipSplit','ticksTooltip','reversed','enabled','naturalArrowKeys','focus'];
 const stringApiSurface = ['selection','tooltip','tooltipSeparator','tooltipPosition','selection','handle','scale','orientation'];
 const arrayApiSurface = ['ticks','ticksPositions','ticksLabels'];
 const functionalApiSurface = ['formatter'];
@@ -45,6 +45,7 @@ export default Ember.Component.extend({
   tooltipSeparator: ':', // used in ranges
   tooltipPosition: 'top',
   tooltipSplit: false, // if false only one tooltip for ranges, if true then tooltips for both
+  ticksTooltip: false,
   handle: 'round', // values are round, square, triangle, or custom
   reversed: false,
   enabled: Ember.computed("disabled", {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-slider",
   "dependencies": {
-    "seiyria-bootstrap-slider": "~7.1.2",
+    "seiyria-bootstrap-slider": "^9.7.2",
     "showdown": "^1.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for [seiyria/bootstrap-slider](https://github.com/seiyria/bootstrap-slider#options) `ticks_tooltip` option.
Also updates library version in `bower.json` as such option was added in version `9.3.0`